### PR TITLE
Address TODOs: fix history default, deduplicate headers

### DIFF
--- a/api/client.py
+++ b/api/client.py
@@ -15,6 +15,12 @@ from config import (
     user_agent,
 )
 
+DEFAULT_POST_HEADER: dict[str, str] = {
+    "accept": "application/json",
+    "Content-Type": "application/json",
+    "Cache-Control": "no-cache",
+}
+
 session = FuturesSession(max_workers=MAX_WORKERS)
 session.headers.update(user_agent)
 
@@ -58,9 +64,6 @@ def create_post_futures(
     all_futures: list[Future] = []
     for url_json_header in urls_json_headers:
         url: str = url_json_header.url
-        # TODO: `header` can probably be de-duplicated. If we know we are create post
-        #   futures, we don't need to add the headers to every URL. Needs to be changed
-        #   in `create_name_urls_json_headers` in `api.urls`
         ids: list[int] = url_json_header.ids
         header: dict[str, str] = url_json_header.header
         future: Future[Response] = session.post(url, json=ids, headers=header)

--- a/api/urls.py
+++ b/api/urls.py
@@ -1,4 +1,4 @@
-from api.client import UrlJsonHeader
+from api.client import DEFAULT_POST_HEADER, UrlJsonHeader
 from processing.constants import ID_SEGMENT_CHUNK, GlobalOrders, Order
 
 
@@ -26,24 +26,16 @@ def create_item_history_url(region: str, item_id: int) -> str:
 def create_name_urls_json_headers(ids: list[int]) -> list[UrlJsonHeader]:
     ujhs: list[UrlJsonHeader] = []
     url: str = "https://esi.evetech.net/latest/universe/names/?datasource=tranquility"
-    # TODO: `header` can probably be de-duplicated. If we know we are create post
-    #   futures, we don't need to add the headers to every URL. Changes need to be made
-    #   in `api.client.py` as well.
-    header: dict[str, str] = {
-        "accept": "application/json",
-        "Content-Type": "application/json",
-        "Cache-Control": "no-cache",
-    }
     if len(ids) <= ID_SEGMENT_CHUNK:
         id_segment: list[int] = ids
-        ujhs.append(UrlJsonHeader(url=url, ids=id_segment, header=header))
+        ujhs.append(UrlJsonHeader(url=url, ids=id_segment, header=DEFAULT_POST_HEADER))
         return ujhs
     segmented_ids: list[list[int]] = []
     for i in range(0, len(ids), ID_SEGMENT_CHUNK):
         end: int = ID_SEGMENT_CHUNK + i
         segmented_ids.append(ids[i:end])
     for id_segment in segmented_ids:
-        ujhs.append(UrlJsonHeader(url=url, ids=id_segment, header=header))
+        ujhs.append(UrlJsonHeader(url=url, ids=id_segment, header=DEFAULT_POST_HEADER))
 
     return ujhs
 

--- a/processing/analysis.py
+++ b/processing/analysis.py
@@ -146,14 +146,10 @@ def add_history_to_processed_data(
                 for history in global_orders[region].all_order_history
                 if history.type_id == type_id
             ),
-            [],
+            None,
         )
         actionable_data[region][name]["history"] = item_history
     else:
-        # TODO: Maybe change this empty list with a nil, or something else? The type is
-        #   of ItemHistory. You could extend this type to have the name of the item also
-        #   within it and perhaps this logic could be streamlined/simplified a little
-        #   bit.
         actionable_data[region][name]["history"] = None
 
 


### PR DESCRIPTION
- Change history default from [] to None for cleaner type semantics
- Add DEFAULT_POST_HEADER to avoid duplicating header dict in urls
- Remove header creation from create_name_urls_json_headers
- Remove TODO comments for resolved items

Removes 4 of 6 TODOs. Remaining are type safety improvements.