### PR TITLE
Issue #59: Add tests for deserialize, history, cache modules and rema…

### DIFF
--- a/processing/deserialize.py
+++ b/processing/deserialize.py
@@ -56,6 +56,8 @@ def deserialize_order_items_p2_onwards(
     deserialized_results: list[Order],
     func: Callable[[str, int], str],
 ) -> tuple[list[Order], list[str]]:
+    if total_pages <= 1:
+        return deserialized_results, []
     urls = []
     chunk_length = CHUNK_LENGTH
     for page in range(2, total_pages + 1):
@@ -64,6 +66,7 @@ def deserialize_order_items_p2_onwards(
             urls.append([])
         # urls is a list of url lists of length `chunk_length`.
         urls[(page - 2) // chunk_length].append(url)
+    fr = None
     for chunk_urls in urls:
         pages_futures = cl.create_futures(chunk_urls)
         fr = cl.futures_results(pages_futures)
@@ -85,7 +88,7 @@ def deserialize_order_items_p2_onwards(
                 f"Sleep redo order fetch due to error timer being {fr.error_timer} \
                         seconds",
             )
-    return deserialized_results, fr.redo_urls
+    return deserialized_results, fr.redo_urls if fr else []
 
 
 # Deserializes resulting JSON from futures, used in `get_source_data`

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -1,10 +1,27 @@
+import math
+from unittest.mock import patch
+
 import pytest
 
-from processing.analysis import remove_bad_orders_names
-from processing.constants import GlobalOrders, NameData, RegionOrdersData
+from config import region_hubs
+from processing.analysis import (
+    add_history_to_processed_data,
+    min_max_source_data,
+    process_filtered_data,
+    remove_bad_orders,
+    remove_bad_orders_names,
+)
+from processing.constants import (
+    GlobalOrders,
+    ItemHistory,
+    NameData,
+    Regional_actionable_data,
+    Regional_min_max,
+    RegionOrdersData,
+)
 
 
-class TestRemoveBadOrders:
+class TestRemoveBadOrdersNames:
     def test_removes_blueprints(self):
         """Verify blueprints are filtered out."""
         names = [
@@ -102,3 +119,184 @@ class TestRemoveBadOrders:
 
         with pytest.raises(TypeError, match="not of type `str`"):
             remove_bad_orders_names(global_orders, "Jita")
+
+
+class TestRemoveBadOrders:
+    def test_removes_blueprints_and_expired(self):
+        """Verify remove_bad_orders removes bad orders."""
+        orders = [
+            {
+                "type_id": 1,
+                "is_buy_order": False,
+                "location_id": 60003760,
+                "price": 100.0,
+            },
+            {
+                "type_id": 2,
+                "is_buy_order": False,
+                "location_id": 60003760,
+                "price": 200.0,
+            },
+        ]
+        names = [
+            NameData(category="inventory_type", id=1, name="Tritanium"),
+            NameData(category="inventory_type", id=2, name="Tritanium Blueprint"),
+        ]
+        global_orders: GlobalOrders = {
+            "Jita": RegionOrdersData(
+                all_orders_data=orders,
+                active_order_names=names,
+                all_order_history=[],
+            )
+        }
+
+        result = remove_bad_orders(global_orders, "Jita", [1, 2])
+
+        assert len(result[0]) == 1
+        assert len(result[1]) == 1
+        assert result[1][0].name == "Tritanium"
+
+
+class TestMinMaxSourceData:
+    def test_finds_min_sell_and_max_buy(self):
+        """Verify min_max_source_data captures correct orders."""
+        jita_location = int(region_hubs["Jita"][1])
+        orders = [
+            {
+                "type_id": 1,
+                "is_buy_order": False,
+                "location_id": jita_location,
+                "price": 100.0,
+            },
+            {
+                "type_id": 1,
+                "is_buy_order": False,
+                "location_id": jita_location,
+                "price": 90.0,
+            },
+            {
+                "type_id": 1,
+                "is_buy_order": True,
+                "location_id": jita_location,
+                "price": 80.0,
+            },
+            {
+                "type_id": 1,
+                "is_buy_order": True,
+                "location_id": jita_location,
+                "price": 85.0,
+            },
+        ]
+        names = [NameData(category="inventory_type", id=1, name="Tritanium")]
+        global_orders: GlobalOrders = {
+            "Jita": RegionOrdersData(
+                all_orders_data=orders,
+                active_order_names=names,
+                all_order_history=[],
+            )
+        }
+        regional_min_max: Regional_min_max = {}
+
+        min_max_source_data("Jita", global_orders, regional_min_max)
+
+        assert "Jita" in regional_min_max
+        assert 1 in regional_min_max["Jita"]
+        min_data = regional_min_max["Jita"][1]
+        assert min_data["min"]["price"] == 90.0
+        assert min_data["max"]["price"] == 85.0
+        assert min_data["name"] == "Tritanium"
+
+
+class TestProcessFilteredData:
+    def test_filters_and_processes_data(self):
+        """Verify process_filtered_data filters and processes."""
+        jita_location = int(region_hubs["Jita"][1])
+        amarr_location = int(region_hubs["Amarr"][1])
+        jita_orders = [
+            {
+                "type_id": 1,
+                "is_buy_order": False,
+                "location_id": jita_location,
+                "price": 80000000.0,
+            },
+        ]
+        amarr_orders = [
+            {
+                "type_id": 1,
+                "is_buy_order": False,
+                "location_id": amarr_location,
+                "price": 120000000.0,
+            },
+        ]
+        names = [NameData(category="inventory_type", id=1, name="Tritanium")]
+        global_orders: GlobalOrders = {
+            "Jita": RegionOrdersData(
+                all_orders_data=jita_orders,
+                active_order_names=names,
+                all_order_history=[],
+            ),
+            "Amarr": RegionOrdersData(
+                all_orders_data=amarr_orders,
+                active_order_names=names,
+                all_order_history=[],
+            ),
+        }
+        regional_min_max: Regional_min_max = {
+            "Jita": {1: {"min": jita_orders[0], "name": "Tritanium"}},
+            "Amarr": {1: {"min": amarr_orders[0], "name": "Tritanium"}},
+        }
+        actionable_data: Regional_actionable_data = {}
+
+        process_filtered_data("Amarr", regional_min_max, actionable_data, global_orders)
+
+        assert "Amarr" in actionable_data
+        assert "Tritanium" in actionable_data["Amarr"]
+        data = actionable_data["Amarr"]["Tritanium"]
+        assert data["diff"] == 40000000.0
+        assert not math.isnan(data["jsv_sell_margin"])
+
+
+class TestAddHistoryToProcessedData:
+    def test_adds_history_when_stale(self):
+        """Verify add_history_to_processed_data adds history."""
+        history = ItemHistory(type_id=1, history=[])
+        global_orders: GlobalOrders = {
+            "Jita": RegionOrdersData(
+                all_orders_data=[],
+                active_order_names=[],
+                all_order_history=[history],
+            )
+        }
+        actionable_data: Regional_actionable_data = {
+            "Jita": {"Tritanium": {"name": "Tritanium", "id": 1}}
+        }
+
+        with patch("processing.analysis.df") as mock_df:
+            mock_df.ARE_SAVED_MARKETS_STALE = {"Jita": True}
+            add_history_to_processed_data(
+                global_orders, "Jita", actionable_data, "Tritanium", 1
+            )
+
+        assert "history" in actionable_data["Jita"]["Tritanium"]
+        assert actionable_data["Jita"]["Tritanium"]["history"] == []
+
+    def test_sets_none_when_not_stale_and_no_history(self):
+        """Verify history is None when not stale and no history."""
+        global_orders: GlobalOrders = {
+            "Jita": RegionOrdersData(
+                all_orders_data=[],
+                active_order_names=[],
+                all_order_history=[],
+            )
+        }
+        actionable_data: Regional_actionable_data = {
+            "Jita": {"Tritanium": {"name": "Tritanium", "id": 999}}
+        }
+
+        with patch("processing.analysis.df") as mock_df:
+            mock_df.ARE_SAVED_MARKETS_STALE = {"Jita": False}
+            add_history_to_processed_data(
+                global_orders, "Jita", actionable_data, "Tritanium", 999
+            )
+
+        assert actionable_data["Jita"]["Tritanium"]["history"] is None

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,100 @@
+import csv
+import gzip
+from unittest.mock import MagicMock, patch
+
+from processing.cache import find_missing_orders, load_history_cache
+from processing.constants import GlobalOrders, ItemHistory, RegionOrdersData
+
+
+class TestLoadHistoryCache:
+    def test_loads_history_from_gzip_csv(self, tmp_path):
+        """Verify load_history_cache correctly reads gzipped CSV."""
+        history_file = tmp_path / "test_history.csv.gz"
+        history_data = [
+            {
+                "type_id": 34,
+                "history": (
+                    '[{"average": 100.0, "date": "2025-01-01", "highest": '
+                    '110.0, "lowest": 90.0, "order_count": 50, "volume": 1000}]'
+                ),
+            },
+        ]
+
+        with gzip.open(history_file, "wt") as f:
+            writer = csv.DictWriter(f, fieldnames=["type_id", "history"])
+            writer.writeheader()
+            writer.writerows(history_data)
+
+        with patch("processing.cache.ItemHistory") as mock_item:
+            mock_item.side_effect = lambda type_id, history: ItemHistory(
+                type_id=int(type_id), history=history
+            )
+            with patch("processing.cache.DataclassReader") as mock_reader:
+                mock_reader.return_value = [
+                    ItemHistory(type_id=34, history=[])
+                ]
+                result = load_history_cache("Jita", str(history_file))
+
+        assert len(result) == 1
+        assert result[0].type_id == 34
+
+
+class TestFindMissingOrders:
+    @patch("processing.cache.hs")
+    @patch("processing.cache.df")
+    @patch("processing.cache.os")
+    def test_finds_and_fetches_missing_orders(
+        self, mock_os, mock_df, mock_hs, tmp_path
+    ):
+        """Verify find_missing_orders fetches missing item IDs."""
+        mock_os.path.exists.return_value = True
+        mock_os.path.getsize.return_value = 100
+
+        existing_history = ItemHistory(type_id=34, history=[])
+        missing_history = ItemHistory(type_id=35, history=[])
+
+        global_orders: GlobalOrders = {
+            "Jita": RegionOrdersData(
+                all_orders_data=[],
+                active_order_names=[],
+                all_order_history=[existing_history],
+            )
+        }
+
+        mock_hs.deserialize_history.return_value = [missing_history]
+
+        history_file = tmp_path / "jita_history.csv.gz"
+        history_file.touch()
+
+        with patch("builtins.open", MagicMock()):
+            find_missing_orders(
+                "Jita", global_orders, [34, 35], str(history_file)
+            )
+
+        assert len(global_orders["Jita"].all_order_history) == 2
+        mock_hs.deserialize_history.assert_called_once_with(
+            "10000002", [35]
+        )
+
+    @patch("processing.cache.hs")
+    @patch("processing.cache.df")
+    @patch("processing.cache.os")
+    def test_no_missing_orders(self, mock_os, mock_df, mock_hs):
+        """Verify find_missing_orders does nothing when no missing orders."""
+        mock_os.path.exists.return_value = True
+        mock_os.path.getsize.return_value = 100
+
+        existing_history = ItemHistory(type_id=34, history=[])
+        global_orders: GlobalOrders = {
+            "Jita": RegionOrdersData(
+                all_orders_data=[],
+                active_order_names=[],
+                all_order_history=[existing_history],
+            )
+        }
+
+        history_file = "/tmp/test.csv.gz"
+
+        find_missing_orders("Jita", global_orders, [34], history_file)
+
+        mock_hs.deserialize_history.assert_not_called()

--- a/tests/test_deserialize.py
+++ b/tests/test_deserialize.py
@@ -1,0 +1,103 @@
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from processing.constants import NameData
+from processing.deserialize import (
+    deserialize_order_items,
+    deserialize_order_items_p2_onwards,
+    deserialize_order_names,
+    find_name,
+)
+
+
+class TestFindName:
+    def test_finds_name_by_id(self):
+        """Verify find_name returns correct NameData for given type_id."""
+        names = [
+            NameData(category="inventory_type", id=1, name="Tritanium"),
+            NameData(category="inventory_type", id=2, name="Pyerite"),
+        ]
+        result = find_name(2, names, "Jita")
+        assert result.id == 2
+        assert result.name == "Pyerite"
+
+    def test_raises_when_id_not_found(self):
+        """Verify find_name raises LookupError when type_id not found."""
+        names = [NameData(category="inventory_type", id=1, name="Tritanium")]
+        with pytest.raises(LookupError, match="Could not find the type_id: 999"):
+            find_name(999, names, "Jita")
+
+
+class TestDeserializeOrderItemsP2Onwards:
+    def test_returns_empty_when_single_page(self):
+        """Verify returns empty results when total_pages is 1."""
+        result, redo_urls = deserialize_order_items_p2_onwards(
+            "Jita", 1, [], lambda r, p: f"url{p}"
+        )
+        assert result == []
+        assert redo_urls == []
+
+    @patch("processing.deserialize.cl")
+    def test_processes_multiple_pages(self, mock_cl):
+        """Verify processes pages 2 onwards correctly."""
+        mock_response = MagicMock()
+        mock_response.text = json.dumps([{"type_id": 1, "price": 100.0}])
+
+        mock_fr = MagicMock()
+        mock_fr.results = [mock_response]
+        mock_fr.redo_urls = []
+        mock_fr.error_timer = 0
+        mock_cl.create_futures.return_value = [MagicMock()]
+        mock_cl.futures_results.return_value = mock_fr
+
+        result, redo_urls = deserialize_order_items_p2_onwards(
+            "Jita", 2, [], lambda r, p: f"url{p}"
+        )
+        assert len(result) == 1
+        assert redo_urls == []
+
+
+class TestDeserializeOrderItems:
+    @patch("processing.deserialize.deserialize_order_item_p1")
+    @patch("processing.deserialize.deserialize_order_items_p2_onwards")
+    def test_calls_p1_and_p2(self, mock_p2, mock_p1):
+        """Verify deserialize_order_items calls p1 then p2."""
+        mock_p1.return_value = ([{"type_id": 1}], 2)
+        mock_p2.return_value = ([{"type_id": 1}, {"type_id": 2}], [])
+
+        result, redo_urls = deserialize_order_items(
+            "Jita", [], lambda r, p: f"url{p}"
+        )
+        assert len(result) == 2
+        mock_p1.assert_called_once()
+        mock_p2.assert_called_once()
+
+
+class TestDeserializeOrderNames:
+    @patch("processing.deserialize.cl")
+    def test_deserializes_names_from_post(self, mock_cl):
+        """Verify deserialize_order_names correctly parses POST response."""
+        mock_response = MagicMock()
+        mock_response.text = json.dumps([
+            {"category": "inventory_type", "id": 1, "name": "Tritanium"},
+            {"category": "inventory_type", "id": 2, "name": "Pyerite"},
+        ])
+
+        mock_fr = MagicMock()
+        mock_fr.results = [mock_response]
+        mock_cl.create_post_futures.return_value = [MagicMock()]
+        mock_cl.futures_results.return_value = mock_fr
+
+        with patch(
+            "processing.deserialize.u.create_name_urls_json_headers"
+        ) as mock_urls:
+            mock_urls.return_value = [
+                MagicMock(url="url", ids=[1, 2], header={})
+            ]
+            result = deserialize_order_names([1, 2])
+
+        assert len(result) == 2
+        assert result[0].name == "Tritanium"
+        assert result[1].name == "Pyerite"

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -1,0 +1,164 @@
+import json
+from unittest.mock import MagicMock, patch
+
+from processing.constants import HistoryDataPoint, ItemHistory
+from processing.history import (
+    deserialize_history,
+    deserialize_history_chunk,
+    parse_history_results,
+)
+
+
+class TestParseHistoryResults:
+    def test_parses_valid_history(self):
+        """Verify parse_history_results correctly parses history data."""
+        histories = [ItemHistory(type_id=34, history=[])]
+
+        mock_response = MagicMock()
+        mock_response.url = (
+            "https://esi.evetech.net/v3/markets/10000002/history/?type_id=34"
+        )
+        mock_response.text = json.dumps([
+            {
+                "average": 100.5,
+                "date": "2025-01-01",
+                "highest": 110.0,
+                "lowest": 90.0,
+                "order_count": 50,
+                "volume": 1000,
+            },
+            {
+                "average": 101.0,
+                "date": "2025-01-02",
+                "highest": 111.0,
+                "lowest": 91.0,
+                "order_count": 55,
+                "volume": 1100,
+            },
+        ])
+
+        parse_history_results([mock_response], histories)
+
+        assert len(histories[0].history) == 2
+        assert histories[0].history[0].average == 100.5
+        assert histories[0].history[1].date == "2025-01-02"
+
+    def test_skips_empty_text(self):
+        """Verify parse_history_results skips responses with empty text."""
+        histories = [ItemHistory(type_id=34, history=[])]
+
+        mock_response = MagicMock()
+        mock_response.url = (
+            "https://esi.evetech.net/v3/markets/10000002/history/?type_id=34"
+        )
+        mock_response.text = ""
+
+        parse_history_results([mock_response], histories)
+
+        assert len(histories[0].history) == 0
+
+    def test_skips_invalid_json(self):
+        """Verify parse_history_results skips invalid JSON."""
+        histories = [ItemHistory(type_id=34, history=[])]
+
+        mock_response = MagicMock()
+        mock_response.url = (
+            "https://esi.evetech.net/v3/markets/10000002/history/?type_id=34"
+        )
+        mock_response.text = "invalid json"
+
+        parse_history_results([mock_response], histories)
+
+        assert len(histories[0].history) == 0
+
+    def test_handles_non_list_response(self):
+        """Verify parse_history_results handles non-list JSON response."""
+        histories = [ItemHistory(type_id=34, history=[])]
+
+        mock_response = MagicMock()
+        mock_response.url = (
+            "https://esi.evetech.net/v3/markets/10000002/history/?type_id=34"
+        )
+        mock_response.text = json.dumps({"error": "not a list"})
+
+        parse_history_results([mock_response], histories)
+
+        assert len(histories[0].history) == 0
+
+    def test_skips_response_without_url(self):
+        """Verify parse_history_results skips responses without URL."""
+        histories = [ItemHistory(type_id=34, history=[])]
+
+        mock_response = MagicMock()
+        mock_response.url = None
+
+        parse_history_results([mock_response], histories)
+
+        assert len(histories[0].history) == 0
+
+
+class TestDeserializeHistoryChunk:
+    @patch("processing.history.cl")
+    def test_deserializes_chunk(self, mock_cl):
+        """Verify deserialize_history_chunk processes history URLs."""
+        histories = [ItemHistory(type_id=34, history=[])]
+
+        mock_response = MagicMock()
+        mock_response.url = (
+            "https://esi.evetech.net/v3/markets/10000002/history/?type_id=34"
+        )
+        mock_response.text = json.dumps([
+            {
+                "average": 100.0,
+                "date": "2025-01-01",
+                "highest": 110.0,
+                "lowest": 90.0,
+                "order_count": 50,
+                "volume": 1000,
+            },
+        ])
+
+        mock_fr = MagicMock()
+        mock_fr.results = [mock_response]
+        mock_fr.redo_urls = []
+        mock_fr.error_timer = 0
+        mock_cl.create_history_futures.return_value = [MagicMock()]
+        mock_cl.futures_results.return_value = mock_fr
+
+        result, redo_urls = deserialize_history_chunk(
+            [["url1"]], histories
+        )
+
+        assert len(result[0].history) == 1
+        assert redo_urls == []
+
+
+class TestDeserializeHistory:
+    @patch("processing.history.deserialize_history_chunk")
+    def test_creates_history_entries(self, mock_chunk):
+        """Verify deserialize_history creates ItemHistory for each item."""
+        mock_chunk.return_value = (
+            [
+                ItemHistory(
+                    type_id=34,
+                    history=[
+                        HistoryDataPoint(
+                            average=100.0,
+                            date="2025-01-01",
+                            highest=110.0,
+                            lowest=90.0,
+                            order_count=50,
+                            volume=1000,
+                        )
+                    ],
+                )
+            ],
+            [],
+        )
+
+        with patch("processing.history.u.create_item_history_url") as mock_url:
+            mock_url.return_value = "url"
+            result = deserialize_history("Jita", [34])
+
+        assert len(result) == 1
+        assert result[0].type_id == 34


### PR DESCRIPTION
…ining analysis functions

- Add tests for processing/deserialize.py (find_name, deserialize_order_items, etc.)
- Add tests for processing/history.py (parse_history_results, deserialize_history, etc.)
- Add tests for processing/cache.py (load_history_cache, find_missing_orders)
- Add tests for remaining analysis.py functions (remove_bad_orders, min_max_source_data, process_filtered_data, add_history_to_processed_data)
- Fix bug in deserialize_order_items_p2_onwards for single page handling
- Total test count: 45 (up from 23)